### PR TITLE
feat: pass proper types to svelte

### DIFF
--- a/apps/demo/src/lib/Tags.svelte
+++ b/apps/demo/src/lib/Tags.svelte
@@ -1,4 +1,5 @@
 <script context="module">
     export { default as Addition } from './tags/Addition.svelte';
     export { default as Multiply } from './tags/Multiply.svelte';
+    export { default as Types } from './tags/Types.svelte';
 </script>

--- a/apps/demo/src/lib/tags/Types.svelte
+++ b/apps/demo/src/lib/tags/Types.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    export let string: string;
+    export let number: number;
+    export let boolean: boolean;
+</script>
+
+<b>Types</b>
+<p><b>{string}</b> is typeof <b>{typeof string}</b></p>
+<p><b>{number}</b> is typeof <b>{typeof number}</b></p>
+<p><b>{boolean}</b> is typeof <b>{typeof boolean}</b></p>

--- a/apps/demo/src/routes/playground/tags/+page.markdoc
+++ b/apps/demo/src/routes/playground/tags/+page.markdoc
@@ -1,3 +1,5 @@
 {% addition a=4 b=4 /%}
 
 {% multiply a=3 b=8 /%}
+
+{% types string="lorem ipsum" number=123 boolean=true /%}

--- a/apps/demo/tests/test.ts
+++ b/apps/demo/tests/test.ts
@@ -5,6 +5,16 @@ test('tags work', async ({ page }) => {
 
     expect(await page.content()).toContain('Addition');
     expect(await page.content()).toContain('Multiply');
+    expect(await page.content()).toContain('Types');
+});
+
+test('tags work with types', async ({ page }) => {
+    await page.goto('http://localhost:4173/playground/tags');
+
+    expect(await page.content()).toContain('Types');
+    expect(await page.content()).toContain('<b>lorem ipsum</b> is typeof <b>string</b>');
+    expect(await page.content()).toContain('<b>123</b> is typeof <b>number</b>');
+    expect(await page.content()).toContain('<b>true</b> is typeof <b>boolean</b>');
 });
 
 test('partials work', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,6 +1115,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/html-escaper": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/html-escaper/-/html-escaper-3.0.0.tgz",
+            "integrity": "sha512-OcJcvP3Yk8mjYwf/IdXZtTE1tb/u0WF0qa29ER07ZHCYUBZXSN29Z1mBS+/96+kNMGTFUAbSz9X+pHmHpZrTCw==",
+            "dev": true
+        },
         "node_modules/@types/inquirer": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-6.5.0.tgz",
@@ -2972,6 +2978,11 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/html-escaper": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.0",
@@ -6007,15 +6018,17 @@
         },
         "packages/process": {
             "name": "svelte-markdoc-preprocess",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "license": "MIT",
             "dependencies": {
                 "@markdoc/markdoc": "^0.3.0",
+                "html-escaper": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "svelte": "^4.0.0",
                 "typescript": "^5.0.0"
             },
             "devDependencies": {
+                "@types/html-escaper": "^3.0.0",
                 "@types/js-yaml": "^4.0.5",
                 "@types/node": "^20.4.5",
                 "prettier": "*",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -25,6 +25,7 @@
     "license": "MIT",
     "dependencies": {
         "@markdoc/markdoc": "^0.3.0",
+        "html-escaper": "^3.0.3",
         "js-yaml": "^4.1.0",
         "svelte": "^4.0.0",
         "typescript": "^5.0.0"
@@ -35,6 +36,7 @@
     },
     "homepage": "https://svelte-markdoc-preprocess.pages.dev",
     "devDependencies": {
+        "@types/html-escaper": "^3.0.0",
         "@types/js-yaml": "^4.0.5",
         "@types/node": "^20.4.5",
         "prettier": "*",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte-markdoc-preprocess",
-    "version": "0.1.6",
+    "version": "0.2.0",
     "description": "A Svelte preprocessor that allows you to use Markdoc.",
     "type": "commonjs",
     "keywords": [

--- a/packages/process/src/renderer.ts
+++ b/packages/process/src/renderer.ts
@@ -1,0 +1,109 @@
+import { RenderableTreeNodes, Tag } from '@markdoc/markdoc';
+import { sanitize_for_svelte } from './transformer';
+import { escape } from 'html-escaper';
+
+export function render_html(node: RenderableTreeNodes): string {
+    /**
+     * if the node is a string or number, it's a text node.
+     */
+    if (typeof node === 'string' || typeof node === 'number') {
+        return sanitize_for_svelte(escape(String(node)));
+    }
+
+    /**
+     * if the node is an array, render its items.
+     */
+    if (Array.isArray(node)) {
+        return node.map(render_html).join('');
+    }
+
+    /**
+     * if the node is not a Tag, it's invalid.
+     */
+    if (node === null || typeof node !== 'object' || !Tag.isTag(node)) {
+        return '';
+    }
+
+    const { name, attributes, children = [] } = node;
+
+    if (!name) {
+        return render_html(children);
+    }
+
+    const is_svelte = is_svelte_component(node);
+
+    /**
+     * add attributes to the tag.
+     */
+    let output = `<${name}`;
+    for (const [key, value] of Object.entries(attributes ?? {})) {
+        if (is_svelte) {
+            output += ` ${key.toLowerCase()}=${generate_svelte_attribute_value(
+                value,
+            )}`;
+        } else {
+            output += ` ${key.toLowerCase()}="${sanitize_for_svelte(
+                escape(String(value)),
+            )}"`;
+        }
+    }
+    output += '>';
+
+    /**
+     * if the tag is a void element, it doesn't need a closing tag.
+     */
+    if (is_void_element(name)) {
+        return output;
+    }
+
+    /**
+     * render the children if present.
+     */
+    if (children.length) {
+        output += render_html(children);
+    }
+
+    /**
+     * close the tag.
+     */
+    output += `</${name}>`;
+
+    return output;
+}
+
+function is_void_element(name: string): boolean {
+    return [
+        'area',
+        +'base',
+        'br',
+        'col',
+        'embed',
+        'hr',
+        'img',
+        'input',
+        'link',
+        'meta',
+        'param',
+        'source',
+        'track',
+        'wbr',
+    ].includes(name);
+}
+
+function is_svelte_component(node: RenderableTreeNodes): boolean {
+    return Tag.isTag(node) && node.name.startsWith('INTERNAL__');
+}
+
+function generate_svelte_attribute_value(value: unknown): string {
+    switch (typeof value) {
+        case 'string':
+            return `"${sanitize_for_svelte(escape(String(value)))}"`;
+        case 'number':
+        case 'boolean':
+            return `{${String(value)}}`;
+        case 'object':
+            return `{${JSON.stringify(value)}}`;
+        default:
+            throw new Error(`Invalid attribute value: ${value}`);
+    }
+}

--- a/packages/process/src/renderer.ts
+++ b/packages/process/src/renderer.ts
@@ -74,7 +74,7 @@ export function render_html(node: RenderableTreeNodes): string {
 function is_void_element(name: string): boolean {
     return [
         'area',
-        +'base',
+        'base',
         'br',
         'col',
         'embed',

--- a/packages/process/src/transformer.ts
+++ b/packages/process/src/transformer.ts
@@ -3,7 +3,6 @@ import {
     SchemaAttribute,
     parse as markdocParse,
     transform,
-    renderers,
     NodeType,
     Tag,
     ConfigType,
@@ -23,6 +22,7 @@ import { parse as svelteParse, walk } from 'svelte/compiler';
 import { get_all_files, path_exists, read_file, write_to_file } from './utils';
 import * as default_schema from './default_schema';
 import type { Config } from './config';
+import { render_html } from './renderer';
 
 type Var = {
     name: string;
@@ -130,7 +130,8 @@ export function transformer({
     /**
      * render to html
      */
-    const code = sanitize_for_svelte(renderers.html(nast));
+    // const code = sanitize_for_svelte(render_html(nast));
+    const code = render_html(nast);
 
     let transformed = '';
 

--- a/packages/process/src/transformer.ts
+++ b/packages/process/src/transformer.ts
@@ -19,10 +19,10 @@ import {
 import { dirname, join } from 'path';
 import { load as loadYaml } from 'js-yaml';
 import { parse as svelteParse, walk } from 'svelte/compiler';
+import { render_html } from './renderer';
 import { get_all_files, path_exists, read_file, write_to_file } from './utils';
 import * as default_schema from './default_schema';
 import type { Config } from './config';
-import { render_html } from './renderer';
 
 type Var = {
     name: string;
@@ -130,7 +130,6 @@ export function transformer({
     /**
      * render to html
      */
-    // const code = sanitize_for_svelte(render_html(nast));
     const code = render_html(nast);
 
     let transformed = '';

--- a/packages/process/tests/processor.test.mjs
+++ b/packages/process/tests/processor.test.mjs
@@ -129,7 +129,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="1">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={1}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -138,7 +138,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="2">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={2}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -147,7 +147,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading id="my-id" level="1">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading id="my-id" level={1}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -156,7 +156,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading class="my-class" level="1">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading class="my-class" level={1}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
     });
@@ -180,7 +180,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="1">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={1}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -189,7 +189,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="2">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={2}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -198,7 +198,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading id="my-id" level="1">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading id="my-id" level={1}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -207,7 +207,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading class="my-class" level="1">Hello World</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading class="my-class" level={1}>Hello World</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -302,7 +302,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="1">I am a partial</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={1}>I am a partial</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -311,7 +311,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="1">Lorem Ipsum</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={1}>Lorem Ipsum</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(
@@ -329,7 +329,7 @@ test('preprocessor', async (context) => {
                 filename: 'test.markdoc',
             }),
             {
-                code: `${script}<article><INTERNAL__NODES.Heading level="1">I am nested</INTERNAL__NODES.Heading></article>`,
+                code: `${script}<article><INTERNAL__NODES.Heading level={1}>I am nested</INTERNAL__NODES.Heading></article>`,
             },
         );
         assert.deepEqual(


### PR DESCRIPTION
The renderer would treat svelte components like html tags and therefore always passed strings to attributes. 

The new renderer is a modified version of the HTML renderer, that will identify svelte components and the attribute types passed and treat them accordingly.

```diff
- <Component string="lorem ipsum" number="123" boolean="true" />
+ <Component string="lorem ipsum" number={123} boolean={true} />
```