### PR TITLE
feat: support import with alias

### DIFF
--- a/apps/demo/src/lib/assets/image.jpeg
+++ b/apps/demo/src/lib/assets/image.jpeg
@@ -1,0 +1,1 @@
+../../routes/playground/markdown/image.jpeg

--- a/apps/demo/src/routes/playground/markdown/+page.markdoc
+++ b/apps/demo/src/routes/playground/markdown/+page.markdoc
@@ -21,7 +21,8 @@ Code fences
 ```
 
 ![Images](./image.jpeg?blur=10)
-![Images]($lib/assets/image.jpeg)
+![Images]($lib/assets/image.jpeg?grayscale)
+![Images](assets/image.jpeg?flip)
 ![Images](/favicon.png)
 
 ## Why create Markdoc instead of using an alternative?

--- a/apps/demo/src/routes/playground/markdown/+page.markdoc
+++ b/apps/demo/src/routes/playground/markdown/+page.markdoc
@@ -21,6 +21,7 @@ Code fences
 ```
 
 ![Images](./image.jpeg?blur=10)
+![Images]($lib/assets/image.jpeg)
 ![Images](/favicon.png)
 
 ## Why create Markdoc instead of using an alternative?

--- a/apps/demo/svelte.config.js
+++ b/apps/demo/svelte.config.js
@@ -33,6 +33,9 @@ const config = {
         // If your environment is not supported or you settled on a specific environment, switch out the adapter.
         // See https://kit.svelte.dev/docs/adapters for more information about adapters.
         adapter: adapter(),
+        alias: {
+            assets: 'src/lib/assets',
+        },
     },
 };
 

--- a/packages/process/src/utils.ts
+++ b/packages/process/src/utils.ts
@@ -44,7 +44,11 @@ export function is_external_url(url: string): boolean {
 }
 
 export function is_relative_path(path: string): boolean {
-    return path.startsWith('./') || path.startsWith('../');
+    return (
+        path.startsWith('./') ||
+        path.startsWith('../') ||
+        path.startsWith('$lib')
+    );
 }
 
 export function parse_query_params_from_string(

--- a/packages/process/src/utils.ts
+++ b/packages/process/src/utils.ts
@@ -43,12 +43,12 @@ export function is_external_url(url: string): boolean {
     return url.startsWith('http://') || url.startsWith('https://');
 }
 
+export function is_absolute_path(url: string): boolean {
+    return url.startsWith('/');
+}
+
 export function is_relative_path(path: string): boolean {
-    return (
-        path.startsWith('./') ||
-        path.startsWith('../') ||
-        path.startsWith('$lib')
-    );
+    return !(is_absolute_path(path) || is_external_url(path));
 }
 
 export function parse_query_params_from_string(

--- a/packages/process/tests/processor/images - enhanced - node/source.markdoc
+++ b/packages/process/tests/processor/images - enhanced - node/source.markdoc
@@ -1,3 +1,4 @@
+![]($lib/assets/image.jpeg)
 ![](./image.jpeg)
 ![](../images/image.jpeg)
 ![](image.jpeg)

--- a/packages/process/tests/processor/images - enhanced - node/source.markdoc
+++ b/packages/process/tests/processor/images - enhanced - node/source.markdoc
@@ -1,4 +1,5 @@
 ![]($lib/assets/image.jpeg)
+![](assets/image.jpeg)
 ![](./image.jpeg)
 ![](../images/image.jpeg)
 ![](image.jpeg)


### PR DESCRIPTION
Adds support for `enhanced:img`  import with the alias that user can [configure](https://kit.svelte.dev/docs/configuration#alias) in the svelte config file 
Refactors the `create_schema` in transformer to 
make it pass the json file just one time